### PR TITLE
解决安装依赖包冲突

### DIFF
--- a/连载帖/2.1.1 开发环境搭建.md
+++ b/连载帖/2.1.1 开发环境搭建.md
@@ -1,4 +1,4 @@
-#开发环境搭建 #
+﻿#开发环境搭建 #
 ## 〇.背景 ##
 本文所属目录层次为：  
 
@@ -55,7 +55,10 @@ git clone https://github.com/linux-sunxi/sunxi-tools.git
 ```
 sudo apt-get install git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev libc6-dev \
 lib32ncurses5-dev gcc-multilib x11proto-core-dev libx11-dev lib32z1-dev libgl1-mesa-dev \
-g++-multilib mingw32 tofrodos python-markdown libxml2-utils gcc-arm-linux-gnueabihf
+g++-multilib mingw32 tofrodos python-markdown libxml2-utils
+```
+```
+sudo apt-get install gcc-arm-linux-gnueabihf
 ```
 > \* 什么叫安装依赖？前面安装的这都是啥？
 > \* 安装的时候是不是有个别依赖没装上？怎么解决？


### PR DESCRIPTION
安装依赖包时gcc-arm-linux-gnueabihf和gcc-multilib冲突 将其分开安装 方便小白 
